### PR TITLE
Adjust isPcr scripts to a more flexible intermediate tally file layout

### DIFF
--- a/primer_selection/isPcr_lineage_report.py
+++ b/primer_selection/isPcr_lineage_report.py
@@ -100,7 +100,7 @@ parser.add_argument(
     "--output",
     metavar="STEM",
     required=True,
-    help="Filename stem for reports (STEM.xlsx and STEM_*.tsv).",
+    help="Filename stem for reports (STEM.xlsx, STEM.pdf, and STEM_*.tsv).",
 )
 parser.add_argument(
     "-r",

--- a/primer_selection/isPcr_lineage_tally.py
+++ b/primer_selection/isPcr_lineage_tally.py
@@ -9,15 +9,18 @@ import sys
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.9.1")
+    print("v0.9.2")
     sys.exit(0)
 
 usage = """\
 Parses a set of FASTA files and isPcr BED output files, to
-produce a single TSV with one column per primer pair, and one
-row for each taxonomic lineage inferred from the FASTA headers.
-This is then used with sister script ``isPcr_lineage_report.py``
-to produce tables.
+report on the expected product legnths expected to amplify
+per primer and per lineage. Produces a single TSV with one
+column per primer pair, and one row for each taxonomic lineage
+inferred from the FASTA headers. Each value is a semi-colon
+separated list of any amplicon lengths for each in-silico PCR
+combination. This is then used with sister script
+``isPcr_lineage_report.py`` to produce tables and plots.
 
 Inputs:
 


### PR DESCRIPTION
Also bumping them to v1.0.0

For my use-case the original form had:

* lineage from FASTA description
* count of one
* primer values...

Now has:

* FASTA identifier
* FASTA description (here lineage)
* primer values...

This means the tally script no longer attempts any summation by lineage, that is all in the reporting script.